### PR TITLE
Remove unnecessary condition check

### DIFF
--- a/lab4/catch_a_ball.py
+++ b/lab4/catch_a_ball.py
@@ -79,7 +79,7 @@ while not finished:
     for event in pygame.event.get():
         if event.type == pygame.QUIT:
             finished = True
-        if event.type == pygame.MOUSEBUTTONDOWN:
+        elif event.type == pygame.MOUSEBUTTONDOWN:
             anyhit = False
             for i in range(number_of_balls):
                 hit = (event.pos[0]-balls[i][0])**2+\


### PR DESCRIPTION
The two conditions `event.type == pygame.QUIT` and
`event.type == pygame.MOUSEBUTTONDOWN` are mutually exclusive, therefore
in case the first one succeeds checking the second one is
unnecessary. So `elif` should be used, which only checks the condition
if the first one fails.